### PR TITLE
Fix deferred request linked list

### DIFF
--- a/README.org
+++ b/README.org
@@ -219,7 +219,7 @@ call =yhs_defer_response= to do this.
 
 Requests with deferred responses are held in a list, so you can work
 through them later. You can maintain one list of all such requests, or
-have multiple lists.
+have multiple lists. A request can only be a member of a single list.
 
 Each list is represented by a =yhsRequest *=, holding a pointer to the
 head. It should start out NULL.
@@ -245,13 +245,13 @@ up and remove it from the list.
 
 The expected code is along these lines:
 
-: yhsRequest **cur=&list;
-: while(*cur) {
+: yhsRequest *cur=list;
+: while(cur) {
 :     /* do stuff to **cur */
 :     if(/* finished with **cur */)
-:         yhs_end_deferred_response(cur);
+:         cur = yhs_end_deferred_response(cur);
 :     else
-:         yhs_next_request_ptr(cur);
+:         cur = yhs_next_request_ptr(cur, &list);
 : }
 
 ** Content

--- a/yhs.h
+++ b/yhs.h
@@ -505,15 +505,15 @@ YHS_EXTERN yhsBool yhs_defer_response(yhsRequest *re,yhsRequest **chain);
 
 // Method of iteration:
 //
-// yhsRequest **ptr=&whatever;//whatever was passed in to yhs_defer_response
-// while(*ptr) {
+// yhsRequest *ptr=chain; // chain is whatever was passed in to yhs_defer_response
+// while(ptr) {
 //     if(done)
-//         yhs_end_deferred_response(ptr);
+//         ptr = yhs_end_deferred_response(ptr, &chain);
 //     else
-//         yhs_next_request_ptr(ptr);
+//         ptr = yhs_next_request_ptr(ptr);
 
-YHS_EXTERN void yhs_next_request_ptr(yhsRequest **re_ptr);
-YHS_EXTERN void yhs_end_deferred_response(yhsRequest **re_ptr);
+YHS_EXTERN yhsRequest *yhs_next_request_ptr(yhsRequest *re);
+YHS_EXTERN yhsRequest *yhs_end_deferred_response(yhsRequest *re, yhsRequest **chain);
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`yhs_next_request_ptr` was a no-op, and `yhs_end_deferred_response` would
move the head of the list when iterating. Simply fixing
`yhs_next_request_ptr` would mean that you had no way to re-iterate the
list, as you would have "lost" your head pointer.