### PR TITLE
fix build on macOS

### DIFF
--- a/yhs.c
+++ b/yhs.c
@@ -1634,8 +1634,13 @@ static void close_connection_cleanly(yhsRequest *re)
 			break;
 	}
 
+#ifdef __APPLE__
+	if(shutdown(re->sock,SHUT_WR)<0)
+		SERVER_SOCKET_ERROR(re->server,"shutdown with SHUT_WR during clean close - this error will be ignored");
+#else
 	if(shutdown(re->sock,SD_SEND)<0)
 		SERVER_SOCKET_ERROR(re->server,"shutdown with SD_SEND during clean close - this error will be ignored");
+#endif
 
 	for(;;)
 	{

--- a/yhs.h
+++ b/yhs.h
@@ -306,7 +306,7 @@ YHS_EXTERN void yhs_text(yhsRequest *req,const char *text);
 //
 // - Response data is automatically discarded when processing a HEAD request.
 //
-YHS_EXTERN void yhs_html_textf(yhsRequest *req,const char *fmt,...) YHS_PRINTF_LIKE(3,4);
+YHS_EXTERN void yhs_html_textf(yhsRequest *req,const char *fmt,...) YHS_PRINTF_LIKE(2,3);
 YHS_EXTERN void yhs_html_textv(yhsRequest *req,const char *fmt,va_list v);
 YHS_EXTERN void yhs_html_text(yhsRequest *req,const char *text);
 


### PR DESCRIPTION
On Xcode `Version 9.2 (9C40b)` with clang `Apple LLVM version 9.0.0 (clang-900.0.39.2)` and macOS Sierra `Version 10.12.6 (16G29)`, the build did not work due to some errors. I have corrected them by doing the following:

* `SD_SEND` is not defined, the equivalent is `SHUT_WR` (actually, `SD_SEND` is typically a re-definition of `SHUT_WR`). Add a case checking if the compiler is targeting apple devices and use `SHUT_WR` instead.
* `YHS_PRINTF_LIKE(3,4)` was giving me an index out of range error. I looked at the code a few lines up (line 278) and it appears like the correct numbering was `YHS_PRINTF_LIKE(2,3)` so I changed it to this.

Tested as working on my setup (listed above) only. Don't think this should affect any other builds.